### PR TITLE
Fix incompatible types error

### DIFF
--- a/lib/ex_marshal/errors/decode_error.ex
+++ b/lib/ex_marshal/errors/decode_error.ex
@@ -2,7 +2,7 @@ defmodule ExMarshal.Errors.DecodeError do
   defexception [:reason]
 
   def message(%__MODULE__{} = exception) do
-    case exception.reason() do
+    case exception.reason do
       {:ivar_string_only, term} ->
         "only string ivars are supported: #{inspect(term)}"
       {:invalid_encoding, term} ->

--- a/lib/ex_marshal/errors/encode_error.ex
+++ b/lib/ex_marshal/errors/encode_error.ex
@@ -2,7 +2,7 @@ defmodule ExMarshal.Errors.EncodeError do
   defexception [:reason]
 
   def message(%__MODULE__{} = exception) do
-    case exception.reason() do
+    case exception.reason do
       {:not_supported, term} ->
         "the following type is not supported: #{inspect(term)}"
     end


### PR DESCRIPTION
## Description of the change

I have https://github.com/gaynetdinov/ex_marshal/pull/32 open, but not sure when it will get merged.

Fix the following error:
```
warning: incompatible types:

    %ExMarshal.Errors.EncodeError{} !~ atom()

in expression:

    # lib/ex_marshal/errors/encode_error.ex:5
    exception.reason()

where "exception" was given the type %ExMarshal.Errors.EncodeError{} in:

    # lib/ex_marshal/errors/encode_error.ex:4
    %ExMarshal.Errors.EncodeError{} = exception

where "exception" was given the type atom() (due to calling var.fun()) in:

    # lib/ex_marshal/errors/encode_error.ex:5
    exception.reason()

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/ex_marshal/errors/encode_error.ex:5: ExMarshal.Errors.EncodeError.message/1

warning: incompatible types:

    %ExMarshal.Errors.DecodeError{} !~ atom()

in expression:

    # lib/ex_marshal/errors/decode_error.ex:5
    exception.reason()

where "exception" was given the type %ExMarshal.Errors.DecodeError{} in:

    # lib/ex_marshal/errors/decode_error.ex:4
    %ExMarshal.Errors.DecodeError{} = exception

where "exception" was given the type atom() (due to calling var.fun()) in:

    # lib/ex_marshal/errors/decode_error.ex:5
    exception.reason()

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/ex_marshal/errors/decode_error.ex:5: ExMarshal.Errors.DecodeError.message/1
```

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> Link to Shortcut/Jira Ticket Goes Here

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
